### PR TITLE
chore: Update dAiv officer list

### DIFF
--- a/dist/res/templates/years/2025/team.html
+++ b/dist/res/templates/years/2025/team.html
@@ -41,7 +41,7 @@
         <span>▹ Directorate of Finance and Admin | 다이브의 재정과 인사, 막동 ∘ MT 등 각종 행사를 기획하여 운영합니다.</span>
     </div>
     <div class="row gy-4">
-        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="250">
+        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="100">
             <a href="https://github.com/youngeun0108">
                 <div class="member">
                     <img src="https://avatars.githubusercontent.com/u/170337089?v=4" class="img-fluid shadow-sm" alt="">
@@ -71,13 +71,33 @@
                 </div>
             </a>
         </div>
-        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="300">
+        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="250">
             <a href="https://github.com/Blummerhen">
                 <div class="member">
                     <img src="https://avatars.githubusercontent.com/u/174010977?v=4" class="img-fluid shadow-sm" alt="">
                     <h4>24학번 김민준</h4>
                     <p>인공지능학과</p>
                     <span>총무부원</span>
+                </div>
+            </a>
+        </div>
+        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="300">
+            <a href="https://github.com/nij0ey">
+                <div class="member">
+                    <img src="https://avatars.githubusercontent.com/u/202369265?v=4" class="img-fluid shadow-sm" alt="">
+                    <h4>25학번 김여진</h4>
+                    <p>인공지능학과</p>
+                    <span>디자이너</span>
+                </div>
+            </a>
+        </div>
+        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="350">
+            <a href="https://github.com/seon5658">
+                <div class="member">
+                    <img src="https://avatars.githubusercontent.com/u/207022234?v=4" class="img-fluid shadow-sm" alt="">
+                    <h4>25학번 남궁선</h4>
+                    <p>인공지능학과</p>
+                    <span>디자이너</span>
                 </div>
             </a>
         </div>
@@ -99,10 +119,10 @@
             </a>
         </div>
         <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="150">
-            <a href="https://github.com/YCY0212">
+            <a href="https://github.com/Mir47-47">
                 <div class="member">
-                    <img src="https://avatars.githubusercontent.com/u/170339074?v=4" class="img-fluid shadow-sm" alt="">
-                    <h4>24학번 윤찬영</h4>
+                    <img src="https://avatars.githubusercontent.com/u/53306904?v=4" class="img-fluid shadow-sm" alt="">
+                    <h4>22학번 김진우</h4>
                     <p>인공지능학과</p>
                     <span>정보차장</span>
                 </div>
@@ -119,12 +139,32 @@
             </a>
         </div>
         <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="250">
-            <a href="https://github.com/rshyun">
+            <a href="https://github.com/sesame-leaf">
                 <div class="member">
-                    <img src="https://avatars.githubusercontent.com/u/168539171?v=4" class="img-fluid shadow-sm" alt="">
-                    <h4>24학번 류시현</h4>
+                    <img src="https://avatars.githubusercontent.com/u/202104674?v=4" class="img-fluid shadow-sm" alt="">
+                    <h4>25학번 방준석</h4>
                     <p>인공지능학과</p>
-                    <span>정보부원</span>
+                    <span>정보인턴</span>
+                </div>
+            </a>
+        </div>
+        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="300">
+            <a href="https://github.com/hndn00">
+                <div class="member">
+                    <img src="https://avatars.githubusercontent.com/u/200548309?v=4" class="img-fluid shadow-sm" alt="">
+                    <h4>25학번 한다연</h4>
+                    <p>첨단융합학부</p>
+                    <span>정보인턴</span>
+                </div>
+            </a>
+        </div>
+        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="350">
+            <a href="https://github.com/kimgm1001">
+                <div class="member">
+                    <img src="https://avatars.githubusercontent.com/u/205116545?v=4" class="img-fluid shadow-sm" alt="">
+                    <h4>25학번 김기민</h4>
+                    <p>첨단융합학부</p>
+                    <span>정보인턴</span>
                 </div>
             </a>
         </div>
@@ -132,7 +172,7 @@
 
     <div class="mx-2 mb-3 mt-5">
         <h2>교육부</h2>
-        <span>▹ Directorate of Education and Learning | Bottom-Up 방식으로 이론적인 지식을 탐구하며, 동아리 인원들 대상 교육과 세미나, 멘토링, 대회를 진행합니다.</span>
+        <span>▹ Directorate of Education and Learning | Bottom-Up 방식으로 이론적인 지식을 탐구하며, 동아리 인원들 대상 교육과 세미나를 진행합니다.</span>
     </div>
     <div class="row gy-4">
         <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="100">
@@ -192,6 +232,106 @@
                     <h4>24학번 신지원</h4>
                     <p>인공지능학과</p>
                     <span>교육부원 | CV 담당</span>
+                </div>
+            </a>
+        </div>
+        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="400">
+            <a href="https://github.com/rnoro5122">
+                <div class="member">
+                    <img src="https://avatars.githubusercontent.com/u/162132940?v=4" class="img-fluid shadow-sm" alt="">
+                    <h4>24학번 이종욱</h4>
+                    <p>인공지능학과</p>
+                    <span>교육부원 | FL 담당</span>
+                </div>
+            </a>
+        </div>
+        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="450">
+            <a href="https://github.com/Codingfetus">
+                <div class="member">
+                    <img src="https://avatars.githubusercontent.com/u/87161923?v=4" class="img-fluid shadow-sm" alt="">
+                    <h4>25학번 문이안</h4>
+                    <p>인공지능학과</p>
+                    <span>교육튜터</span>
+                </div>
+            </a>
+        </div>
+        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="500">
+            <a href="https://github.com/jiheepark06">
+                <div class="member">
+                    <img src="https://avatars.githubusercontent.com/u/199187115?v=4" class="img-fluid shadow-sm" alt="">
+                    <h4>25학번 박지희</h4>
+                    <p>인공지능학과</p>
+                    <span>교육튜터</span>
+                </div>
+            </a>
+        </div>
+        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="550">
+            <a href="https://github.com/yogo883">
+                <div class="member">
+                    <img src="https://avatars.githubusercontent.com/u/200927490?v=4" class="img-fluid shadow-sm" alt="">
+                    <h4>25학번 박현영</h4>
+                    <p>인공지능학과</p>
+                    <span>교육튜터</span>
+                </div>
+            </a>
+        </div>
+        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="600">
+            <a href="https://github.com/ownstj">
+                <div class="member">
+                    <img src="https://avatars.githubusercontent.com/u/39269564?v=4" class="img-fluid shadow-sm" alt="">
+                    <h4>25학번 오준서</h4>
+                    <p>인공지능학과</p>
+                    <span>교육튜터</span>
+                </div>
+            </a>
+        </div>
+        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="650">
+            <a href="https://github.com/rudcoco">
+                <div class="member">
+                    <img src="https://avatars.githubusercontent.com/u/206585956?v=4" class="img-fluid shadow-sm" alt="">
+                    <h4>25학번 윤채경</h4>
+                    <p>인공지능학과</p>
+                    <span>교육튜터</span>
+                </div>
+            </a>
+        </div>
+        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="700">
+            <a href="https://github.com/suwan9393">
+                <div class="member">
+                    <img src="https://avatars.githubusercontent.com/u/199436015?v=4" class="img-fluid shadow-sm" alt="">
+                    <h4>25학번 이수완</h4>
+                    <p>인공지능학과</p>
+                    <span>교육튜터</span>
+                </div>
+            </a>
+        </div>
+        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="750">
+            <a href="https://github.com/pengineu">
+                <div class="member">
+                    <img src="https://avatars.githubusercontent.com/u/132439070?v=4" class="img-fluid shadow-sm" alt="">
+                    <h4>25학번 이신재</h4>
+                    <p>인공지능학과</p>
+                    <span>교육튜터</span>
+                </div>
+            </a>
+        </div>
+        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="800">
+            <a href="https://github.com/Hano0196">
+                <div class="member">
+                    <img src="https://avatars.githubusercontent.com/u/201733323?v=4" class="img-fluid shadow-sm" alt="">
+                    <h4>25학번 이현태</h4>
+                    <p>인공지능학과</p>
+                    <span>교육튜터</span>
+                </div>
+            </a>
+        </div>
+        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="850">
+            <a href="https://github.com/lightspear1121">
+                <div class="member">
+                    <img src="https://avatars.githubusercontent.com/u/199609217?v=4" class="img-fluid shadow-sm" alt="">
+                    <h4>25학번 현창엽</h4>
+                    <p>인공지능학과</p>
+                    <span>교육튜터</span>
                 </div>
             </a>
         </div>

--- a/dist/res/templates/years/2025/team.html
+++ b/dist/res/templates/years/2025/team.html
@@ -41,7 +41,7 @@
         <span>▹ Directorate of Finance and Admin | 다이브의 재정과 인사, 막동 ∘ MT 등 각종 행사를 기획하여 운영합니다.</span>
     </div>
     <div class="row gy-4">
-        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="250">
+        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="100">
             <a href="https://github.com/youngeun0108">
                 <div class="member">
                     <img src="https://avatars.githubusercontent.com/u/170337089?v=4" class="img-fluid shadow-sm" alt="">
@@ -71,7 +71,7 @@
                 </div>
             </a>
         </div>
-        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="300">
+        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="250">
             <a href="https://github.com/Blummerhen">
                 <div class="member">
                     <img src="https://avatars.githubusercontent.com/u/174010977?v=4" class="img-fluid shadow-sm" alt="">
@@ -81,11 +81,31 @@
                 </div>
             </a>
         </div>
+        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="300">
+            <a href="https://github.com/nij0ey">
+                <div class="member">
+                    <img src="https://avatars.githubusercontent.com/u/202369265?v=4" class="img-fluid shadow-sm" alt="">
+                    <h4>25학번 김여진</h4>
+                    <p>인공지능학과</p>
+                    <span>디자이너</span>
+                </div>
+            </a>
+        </div>
+        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="350">
+            <a href="https://github.com/seon5658">
+                <div class="member">
+                    <img src="https://avatars.githubusercontent.com/u/207022234?v=4" class="img-fluid shadow-sm" alt="">
+                    <h4>25학번 남궁선</h4>
+                    <p>인공지능학과</p>
+                    <span>디자이너</span>
+                </div>
+            </a>
+        </div>
     </div>
 
     <div class="mx-2 mb-3 mt-5">
         <h2>정보부</h2>
-        <span>▹ Directorate of Information and Technology | Top-Down 형태로 실용적인 지식을 탐구하며, 다이브의 시스템을 관리합니다.</span>
+        <span>▹ Directorate of Information and Technology | Top-Down 형태로 실용적인 지식을 탐구하며, 다이브의 시스템을 관리하고 대회를 주관합니다.</span>
     </div>
     <div class="row gy-4">
         <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="100">
@@ -99,10 +119,10 @@
             </a>
         </div>
         <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="150">
-            <a href="https://github.com/YCY0212">
+            <a href="https://github.com/Mir47-47">
                 <div class="member">
-                    <img src="https://avatars.githubusercontent.com/u/170339074?v=4" class="img-fluid shadow-sm" alt="">
-                    <h4>24학번 윤찬영</h4>
+                    <img src="https://avatars.githubusercontent.com/u/53306904?v=4" class="img-fluid shadow-sm" alt="">
+                    <h4>22학번 김진우</h4>
                     <p>인공지능학과</p>
                     <span>정보차장</span>
                 </div>
@@ -119,12 +139,32 @@
             </a>
         </div>
         <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="250">
-            <a href="https://github.com/rshyun">
+            <a href="https://github.com/sesame-leaf">
                 <div class="member">
-                    <img src="https://avatars.githubusercontent.com/u/168539171?v=4" class="img-fluid shadow-sm" alt="">
-                    <h4>24학번 류시현</h4>
+                    <img src="https://avatars.githubusercontent.com/u/202104674?v=4" class="img-fluid shadow-sm" alt="">
+                    <h4>25학번 방준석</h4>
                     <p>인공지능학과</p>
-                    <span>정보부원</span>
+                    <span>정보인턴</span>
+                </div>
+            </a>
+        </div>
+        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="300">
+            <a href="https://github.com/hndn00">
+                <div class="member">
+                    <img src="https://avatars.githubusercontent.com/u/200548309?v=4" class="img-fluid shadow-sm" alt="">
+                    <h4>25학번 한다연</h4>
+                    <p>첨단융합학부</p>
+                    <span>정보인턴</span>
+                </div>
+            </a>
+        </div>
+        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="350">
+            <a href="https://github.com/kimgm1001">
+                <div class="member">
+                    <img src="https://avatars.githubusercontent.com/u/205116545?v=4" class="img-fluid shadow-sm" alt="">
+                    <h4>25학번 김기민</h4>
+                    <p>첨단융합학부</p>
+                    <span>정보인턴</span>
                 </div>
             </a>
         </div>
@@ -132,7 +172,7 @@
 
     <div class="mx-2 mb-3 mt-5">
         <h2>교육부</h2>
-        <span>▹ Directorate of Education and Learning | Bottom-Up 방식으로 이론적인 지식을 탐구하며, 동아리 인원들 대상 교육과 세미나, 멘토링, 대회를 진행합니다.</span>
+        <span>▹ Directorate of Education and Learning | Bottom-Up 방식으로 이론적인 지식을 탐구하며, 동아리 인원들 대상 교육과 세미나를 진행합니다.</span>
     </div>
     <div class="row gy-4">
         <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="100">
@@ -165,7 +205,7 @@
                 </div>
             </a>
         </div>
-        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="300">
+        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="250">
             <a href="https://github.com/shinsurim">
                 <div class="member">
                     <img src="https://avatars.githubusercontent.com/u/97718573?v=4" class="img-fluid shadow-sm" alt="">
@@ -175,7 +215,7 @@
                 </div>
             </a>
         </div>
-        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="350">
+        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="300">
             <a href="https://github.com/jiyeol9081">
                 <div class="member">
                     <img src="https://avatars.githubusercontent.com/u/173701865?v=4" class="img-fluid shadow-sm" alt="">
@@ -185,7 +225,7 @@
                 </div>
             </a>
         </div>
-        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="400">
+        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="350">
             <a href="https://github.com/shjiwon">
                 <div class="member">
                     <img src="https://avatars.githubusercontent.com/u/174260127?v=4" class="img-fluid shadow-sm" alt="">
@@ -195,6 +235,107 @@
                 </div>
             </a>
         </div>
+        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="400">
+            <a href="https://github.com/rnoro5122">
+                <div class="member">
+                    <img src="https://avatars.githubusercontent.com/u/162132940?v=4" class="img-fluid shadow-sm" alt="">
+                    <h4>24학번 이종욱</h4>
+                    <p>인공지능학과</p>
+                    <span>교육부원 | FL 담당</span>
+                </div>
+            </a>
+        </div>
+        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="450">
+            <a href="https://github.com/Codingfetus">
+                <div class="member">
+                    <img src="https://avatars.githubusercontent.com/u/87161923?v=4" class="img-fluid shadow-sm" alt="">
+                    <h4>25학번 문이안</h4>
+                    <p>인공지능학과</p>
+                    <span>교육튜터</span>
+                </div>
+            </a>
+        </div>
+        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="500">
+            <a href="https://github.com/jiheepark06">
+                <div class="member">
+                    <img src="https://avatars.githubusercontent.com/u/199187115?v=4" class="img-fluid shadow-sm" alt="">
+                    <h4>25학번 박지희</h4>
+                    <p>인공지능학과</p>
+                    <span>교육튜터</span>
+                </div>
+            </a>
+        </div>
+        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="550">
+            <a href="https://github.com/yogo883">
+                <div class="member">
+                    <img src="https://avatars.githubusercontent.com/u/200927490?v=4" class="img-fluid shadow-sm" alt="">
+                    <h4>25학번 박현영</h4>
+                    <p>인공지능학과</p>
+                    <span>교육튜터</span>
+                </div>
+            </a>
+        </div>
+        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="600">
+            <a href="https://github.com/ownstj">
+                <div class="member">
+                    <img src="https://avatars.githubusercontent.com/u/39269564?v=4" class="img-fluid shadow-sm" alt="">
+                    <h4>25학번 오준서</h4>
+                    <p>인공지능학과</p>
+                    <span>교육튜터</span>
+                </div>
+            </a>
+        </div>
+        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="650">
+            <a href="https://github.com/rudcoco">
+                <div class="member">
+                    <img src="https://avatars.githubusercontent.com/u/206585956?v=4" class="img-fluid shadow-sm" alt="">
+                    <h4>25학번 윤채경</h4>
+                    <p>인공지능학과</p>
+                    <span>교육튜터</span>
+                </div>
+            </a>
+        </div>
+        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="700">
+            <a href="https://github.com/suwan9393">
+                <div class="member">
+                    <img src="https://avatars.githubusercontent.com/u/199436015?v=4" class="img-fluid shadow-sm" alt="">
+                    <h4>25학번 이수완</h4>
+                    <p>인공지능학과</p>
+                    <span>교육튜터</span>
+                </div>
+            </a>
+        </div>
+        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="750">
+            <a href="https://github.com/pengineu">
+                <div class="member">
+                    <img src="https://avatars.githubusercontent.com/u/132439070?v=4" class="img-fluid shadow-sm" alt="">
+                    <h4>25학번 이신재</h4>
+                    <p>인공지능학과</p>
+                    <span>교육튜터</span>
+                </div>
+            </a>
+        </div>
+        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="800">
+            <a href="https://github.com/Hano0196">
+                <div class="member">
+                    <img src="https://avatars.githubusercontent.com/u/201733323?v=4" class="img-fluid shadow-sm" alt="">
+                    <h4>25학번 이현태</h4>
+                    <p>인공지능학과</p>
+                    <span>교육튜터</span>
+                </div>
+            </a>
+        </div>
+        <div class="col-xl-2-4 col-lg-3 col-md-4 col-6 d-flex" data-aos="fade-up" data-aos-delay="850">
+            <a href="https://github.com/lightspear1121">
+                <div class="member">
+                    <img src="https://avatars.githubusercontent.com/u/199609217?v=4" class="img-fluid shadow-sm" alt="">
+                    <h4>25학번 현창엽</h4>
+                    <p>인공지능학과</p>
+                    <span>교육튜터</span>
+                </div>
+            </a>
+        </div>
+
     </div>
 
     <div class="mx-2 mb-3 mt-5">

--- a/dist/src/common/main.py
+++ b/dist/src/common/main.py
@@ -37,20 +37,21 @@ def parse_html(htmlstr: str):
 ########################################################################################################################
 # Navigation Bar
 ########################################################################################################################
+def scroll_to(section: str):
+    offset = document.getElementById('header').offsetHeight
+    if section:
+        section_element = document.getElementById(section.split('#')[-1])
+        if section_element:
+            pos = document.getElementById(section.split('#')[-1]).offsetTop
+            window.scrollTo({'top': pos - offset, 'behavior': "smooth"})
+
+
 def enable_navigation():
     navigation = document.getElementsByClassName('nav-link')
     navigation_menus = {nav.attributes['href'].value.split('#')[-1]: nav for nav in navigation}
     header = document.getElementById('header')
     navbar = document.getElementById('navbar')
     mobile_toggles = document.getElementsByClassName('mobile-nav-toggle')
-
-    def scroll_to(section: str):
-        offset = header.offsetHeight
-        if section:
-            section_element = document.getElementById(section.split('#')[-1])
-            if section_element:
-                pos = document.getElementById(section.split('#')[-1]).offsetTop
-                window.scrollTo({'top': pos - offset, 'behavior': "smooth"})
 
     def navbar_click(event):
         # fix default location error

--- a/dist/src/main/index/index.py
+++ b/dist/src/main/index/index.py
@@ -51,7 +51,7 @@ def setup_programs_filter():
 ########################################################################################################################
 # Set Datas by Year
 ########################################################################################################################
-from common.main import current_year, insert_element
+from common.main import current_year, insert_element, scroll_to
 
 
 def change_year_visibility(e):
@@ -214,6 +214,7 @@ if team:
                 if not enabled:  # show only the first queried year
                     enabled = True
                     document.getElementById('team_'+str(year)).classList.remove('d-none')
+                    scroll_to(window.location.hash)
                     window.AOS.init()
                     window.AOS.refresh()
 
@@ -248,6 +249,7 @@ if programs:
                             images.append(img)
                         await aio.sleep(0.001)
 
+                    scroll_to(window.location.hash)
                     window.AOS.init()
                     window.AOS.refresh()
                     setup_programs_filter()


### PR DESCRIPTION
### Update dAiv officer list

- Add nji0ey and seon5658 as a designer in the General Affairs Department.

- Change the deputy head of the Information Department from YCY0212 to Mir47‑47.

- Remove rshyun from the Information Department.

- Add sesame‑leaf, hndn00 and kimgm1001 to the Information Department as interns.

- Add mroso5122 to the Education Department.

- Add Codingfetus, jihepark06, yog9883, ownstj, rudocoo, suwan9393, penginue, Hano0196 and lightspear1121 to the Education Department as interns.

### Adjust the speed at which the officer cards appear when scrolling down the page.

- Modify the scrolling animation so that, as you scroll down the blog, the left‑most first officer card in each department (the head card) plays at speed 100, with every subsequent card’s speed increasing by 50.

### Edit the introduction texts for the Information and Education Departments.

- Change Information Department introduction to:
“Directorate of Information and Technology | We explore practical knowledge through a top‑down approach, manage Dive’s systems, and host competitions.”

- Change Education Department introduction to:
“Directorate of Education and Learning | We explore theoretical knowledge through a bottom‑up approach and conduct training sessions and seminars for our club members.”