### PR TITLE
fix: Resolve redirect bug on program page

### DIFF
--- a/dist/src/common/main.py
+++ b/dist/src/common/main.py
@@ -37,20 +37,20 @@ def parse_html(htmlstr: str):
 ########################################################################################################################
 # Navigation Bar
 ########################################################################################################################
+def scroll_to(section: str):
+    offset = document.getElementById('header').offsetHeight
+    if section:
+        section_element = document.getElementById(section.split('#')[-1])
+        if section_element:
+            pos = document.getElementById(section.split('#')[-1]).offsetTop
+            window.scrollTo({'top': pos - offset, 'behavior': "smooth"})
+
 def enable_navigation():
     navigation = document.getElementsByClassName('nav-link')
     navigation_menus = {nav.attributes['href'].value.split('#')[-1]: nav for nav in navigation}
     header = document.getElementById('header')
     navbar = document.getElementById('navbar')
     mobile_toggles = document.getElementsByClassName('mobile-nav-toggle')
-
-    def scroll_to(section: str):
-        offset = header.offsetHeight
-        if section:
-            section_element = document.getElementById(section.split('#')[-1])
-            if section_element:
-                pos = document.getElementById(section.split('#')[-1]).offsetTop
-                window.scrollTo({'top': pos - offset, 'behavior': "smooth"})
 
     def navbar_click(event):
         # fix default location error

--- a/dist/src/main/index/index.py
+++ b/dist/src/main/index/index.py
@@ -51,7 +51,7 @@ def setup_programs_filter():
 ########################################################################################################################
 # Set Datas by Year
 ########################################################################################################################
-from common.main import current_year, insert_element
+from common.main import current_year, insert_element, scroll_to
 
 
 def change_year_visibility(e):
@@ -214,6 +214,7 @@ if team:
                 if not enabled:  # show only the first queried year
                     enabled = True
                     document.getElementById('team_'+str(year)).classList.remove('d-none')
+                    scroll_to(window.location.hash)
                     window.AOS.init()
                     window.AOS.refresh()
 
@@ -248,6 +249,7 @@ if programs:
                             images.append(img)
                         await aio.sleep(0.001)
 
+                    scroll_to(window.location.hash)
                     window.AOS.init()
                     window.AOS.refresh()
                     setup_programs_filter()


### PR DESCRIPTION
### Description:
This PR fixes an issue where navigating via hash (e.g., #team, #programs) would not properly scroll to the correct section after page load or dynamic content updates.

### Changes Made:

- Refactored scroll_to function:
Moved the scroll_to(section: str) logic to common/main.py for centralized use and removed the duplicate function in main/index.py.

- Integrated scroll_to in dynamic view updates:
Called scroll_to(window.location.hash) after dynamically revealing elements by year (change_year_visibility). Ensured correct scrolling after dynamically appending program elements (setup_programs_filter).

### Why it matters:
Previously, due to asynchronous DOM updates, calling scrollIntoView or manual scroll methods would misfire or land in the wrong section. This fix ensures smooth and accurate navigation after hash-based jumps, especially when the content is loaded dynamically.

